### PR TITLE
GUARD-120 Removed order filtering by status in legacy GetOrdersAsync

### DIFF
--- a/src/WooCommerceAccess/Services/LegacyV3WCObject.cs
+++ b/src/WooCommerceAccess/Services/LegacyV3WCObject.cs
@@ -27,12 +27,7 @@ namespace WooCommerceAccess.Services
 
 		public async Task< IEnumerable< WooCommerceOrder > > GetOrdersAsync( DateTime startDateUtc, DateTime endDateUtc )
 		{
-			var requestParameters = new Dictionary< string, string >
-			{
-				{ "status", "processing" }
-			};
-
-			var orders = await this._legacyApiWCObject.GetOrders( requestParameters ).ConfigureAwait( false );
+			var orders = await this._legacyApiWCObject.GetOrders().ConfigureAwait( false );
 			return orders.Where( order => order.updated_at >= startDateUtc && order.updated_at <= endDateUtc )
 					 .Select( order => order.ToSvOrder() )
 					 .ToArray();

--- a/src/WooCommerceAccess/WooCommerceAccess.csproj
+++ b/src/WooCommerceAccess/WooCommerceAccess.csproj
@@ -9,10 +9,10 @@
     <PackageLicenseUrl>https://github.com/skuvault/wooCommerceAccess/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/wooCommerceAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault/wooCommerceAccess</RepositoryUrl>
-    <Version>0.2.6-rc1</Version>
+    <Version>0.2.7-rc1</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>0.2.6.0</AssemblyVersion>
-    <FileVersion>0.2.6.0</FileVersion>
+    <AssemblyVersion>0.2.7.0</AssemblyVersion>
+    <FileVersion>0.2.7.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We want to get orders with any status