### PR TITLE
2019-11-07 GUARD-293 WooCommerce-Full-Inventory-NRE

### DIFF
--- a/src/WooCommerceAccess/Services/ApiV3WCObject.cs
+++ b/src/WooCommerceAccess/Services/ApiV3WCObject.cs
@@ -176,7 +176,7 @@ namespace WooCommerceAccess.Services
 				id = productQuantity.Id, sku = productQuantity.Sku, stock_quantity = productQuantity.Quantity
 			} ).ToList();
 
-			return ( await UpdateProductsInSequentialBatchesAsync( productsUpdateRequests, BatchSize ) ).ToDictionary( p => p.Sku, p => p.Quantity ?? 0 );
+			return ( await UpdateProductsInSequentialBatchesAsync( productsUpdateRequests, BatchSize ) ).Where( p => !string.IsNullOrWhiteSpace( p.Sku ) ).ToDictionary( p => p.Sku, p => p.Quantity ?? 0 );
 		}
 
 		private async Task< IEnumerable< WooCommerceVariation > > UpdateVariationsAsync( Dictionary< ProductId, IEnumerable< QuantityUpdate > > variationsUpdateRequests )

--- a/src/WooCommerceAccess/WooCommerceAccess.csproj
+++ b/src/WooCommerceAccess/WooCommerceAccess.csproj
@@ -9,10 +9,10 @@
     <PackageLicenseUrl>https://github.com/skuvault/wooCommerceAccess/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/wooCommerceAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault/wooCommerceAccess</RepositoryUrl>
-    <Version>1.0.0.6</Version>
+    <Version>1.0.0.7</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.0.0.6</AssemblyVersion>
-    <FileVersion>1.0.0.6</FileVersion>
+    <AssemblyVersion>1.0.0.7</AssemblyVersion>
+    <FileVersion>1.0.0.7</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
**Summary**
Somehow customer created products with same sku (WP 5.2.4, WooCommerce 3.8).  Nevertheless I didn't succeed in reproducing this issue in the our cloud WooCommerce store, got error "dublicate sku".
NRE was caused by external WooCommerce library during inventory update. In the case of updating products with same sku the library returns updated products without sku field filled.