### PR TITLE
2019-11-26 GUARD-311 User-Agent-Header

### DIFF
--- a/src/WooCommerceAccess/Configuration/WooCommerceConfig.cs
+++ b/src/WooCommerceAccess/Configuration/WooCommerceConfig.cs
@@ -33,10 +33,15 @@ namespace WooCommerceAccess.Configuration
 		/// </summary>
 		public int ProductsPageSize = 10;
 
-    /// <summary>
+		/// <summary>
 		///	Default page size for orders
 		/// </summary>
 		public int OrdersPageSize = 10;
+
+		/// <summary>
+		///	Default HTTP User-Agent header
+		/// </summary>
+		public string DefaultUserAgentHeader = "SkuVault Inc. WooCommerceAccessLibrary";
 
 		public WooCommerceConfig( string shopUrl, string consumerKey, string consumerSecret )
 		{

--- a/src/WooCommerceAccess/Services/Authentication/WooCommerceAuthenticationService.cs
+++ b/src/WooCommerceAccess/Services/Authentication/WooCommerceAuthenticationService.cs
@@ -73,6 +73,8 @@ namespace WooCommerceAccess.Services.Authentication
 			{
 				BaseAddress = new Uri( this._config.ShopUrl )
 			};
+			httpClient.DefaultRequestHeaders.Add( "User-Agent", this._config.DefaultUserAgentHeader );
+
 			var url = this.GetAuthenticationUrl( requestId );
 			var httpResponse = await httpClient.GetAsync( url ).ConfigureAwait( false );
 			return await httpResponse.Content.ReadAsStringAsync().ConfigureAwait( false );

--- a/src/WooCommerceAccess/Services/BaseService.cs
+++ b/src/WooCommerceAccess/Services/BaseService.cs
@@ -39,7 +39,7 @@ namespace WooCommerceAccess.Services
 
 		private void InitWcObject()
 		{
-			apiVersion = new WooCommerceApiVersionDetector( this.Config.ShopUrl, this.Config.RetryAttempts ).DetectApiVersion().Result;
+			apiVersion = new WooCommerceApiVersionDetector( this.Config.ShopUrl, this.Config.RetryAttempts, this.Config.DefaultUserAgentHeader ).DetectApiVersion().Result;
 			
 			if ( apiVersion == WooCommerceApiVersion.Unknown )
 				throw new WooCommerceException( "Unsupported WordPress and WooCommerce version!" );

--- a/src/WooCommerceAccess/Shared/WooCommerceApiVersionDetector.cs
+++ b/src/WooCommerceAccess/Shared/WooCommerceApiVersionDetector.cs
@@ -17,14 +17,16 @@ namespace WooCommerceAccess.Shared
 		private const string JsonApiV3DescriptionUrl = "/wp-json/wc/v3/";
 		private const string ProductsLegacyApiV3Url = "/wc-api/v3/products";
 
-		public WooCommerceApiVersionDetector( string shopUrl, int retryAttempts )
+		public WooCommerceApiVersionDetector( string shopUrl, int retryAttempts, string userAgentHeader )
 		{
 			Condition.Requires( shopUrl, "shopUrl" ).IsNotNullOrWhiteSpace();
 			Condition.Requires( retryAttempts, "retryAttempts" ).IsGreaterThan( 0 );
+			Condition.Requires( userAgentHeader, "userAgentHeader" ).IsNotNullOrWhiteSpace();
 
 			this._shopUrl = shopUrl.TrimEnd( '/' );
 			this._retryAttempts = retryAttempts;
 			this._httpClient = new HttpClient();
+			this._httpClient.DefaultRequestHeaders.Add( "User-Agent", userAgentHeader );
 		}
 
 		public async Task< WooCommerceApiVersion > DetectApiVersion()

--- a/src/WooCommerceAccess/WooCommerceAccess.csproj
+++ b/src/WooCommerceAccess/WooCommerceAccess.csproj
@@ -9,10 +9,10 @@
     <PackageLicenseUrl>https://github.com/skuvault/wooCommerceAccess/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/wooCommerceAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault/wooCommerceAccess</RepositoryUrl>
-    <Version>1.0.0.7</Version>
+    <Version>1.0.0.8</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.0.0.7</AssemblyVersion>
-    <FileVersion>1.0.0.7</FileVersion>
+    <AssemblyVersion>1.0.0.8</AssemblyVersion>
+    <FileVersion>1.0.0.8</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/WooCommerceTests/ApiDetectorTests.cs
+++ b/src/WooCommerceTests/ApiDetectorTests.cs
@@ -12,6 +12,7 @@ namespace WooCommerceTests
 	{
 		private string _shopUrlWithV3ApiVersion;
 		private string _shopUrlWithLegacyApiVersion;
+		private const string DefaultUserAgentHeader = "SkuVault Inc. WooCommerceAccess library";
 
 		[ SetUp ]
 		public void LoadShopList()
@@ -28,7 +29,7 @@ namespace WooCommerceTests
 		[ Test ]
 		public void DetectWooCommerceApiVersion()
 		{
-			var apiDetector = new WooCommerceApiVersionDetector( _shopUrlWithV3ApiVersion, 3 );
+			var apiDetector = new WooCommerceApiVersionDetector( _shopUrlWithV3ApiVersion, 3, DefaultUserAgentHeader );
 
 			var apiVersion = apiDetector.DetectApiVersion().Result;
 			apiVersion.Should().Be( WooCommerceApiVersion.V3 );
@@ -37,7 +38,7 @@ namespace WooCommerceTests
 		[ Test ]
 		public void DetectWooCommerceLegacyApiVersion()
 		{
-			var apiDetector = new WooCommerceApiVersionDetector( _shopUrlWithLegacyApiVersion, 3 );
+			var apiDetector = new WooCommerceApiVersionDetector( _shopUrlWithLegacyApiVersion, 3, DefaultUserAgentHeader );
 
 			var apiVersion = apiDetector.DetectApiVersion().Result;
 			apiVersion.Should().Be( WooCommerceApiVersion.Legacy );


### PR DESCRIPTION
Summary
I added User-Agent header to our HTTP requests because some firewalls filter out requests without it.