### PR TITLE
GUARD-616 v 1.2.3: pointed to wooCommerce.NET.SV 1.1.5: remove system…

### DIFF
--- a/src/WooCommerceAccess/WooCommerceAccess.csproj
+++ b/src/WooCommerceAccess/WooCommerceAccess.csproj
@@ -9,10 +9,10 @@
     <PackageLicenseUrl>https://github.com/skuvault/wooCommerceAccess/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/wooCommerceAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault/wooCommerceAccess</RepositoryUrl>
-    <Version>1.2.2.0</Version>
+    <Version>1.2.3.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.2.2.0</AssemblyVersion>
-    <FileVersion>1.2.2.0</FileVersion>
+    <AssemblyVersion>1.2.3.0</AssemblyVersion>
+    <FileVersion>1.2.3.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,7 +21,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="Polly-Signed" Version="5.9.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="WooCommerceNET.SV" Version="1.1.0.4" />
+    <PackageReference Include="WooCommerceNET.SV" Version="1.1.5" />
   </ItemGroup>
 
 </Project>

--- a/src/WooCommerceTests/AuthTests.cs
+++ b/src/WooCommerceTests/AuthTests.cs
@@ -8,7 +8,7 @@ using WooCommerceAccess.Services.Authentication;
 
 namespace WooCommerceTests
 {
-	[ TestFixture( "WP5_2_WC_3_6_credentials.csv" ) ]
+	[ TestFixture( "credentials_cloud_sandbox.csv" ) ]
 	public class AuthTests : BaseTest
 	{
 		protected WooCommerceAuthenticationService AuthenticationService { get; private set; }

--- a/src/WooCommerceTests/OrderTests.cs
+++ b/src/WooCommerceTests/OrderTests.cs
@@ -6,8 +6,8 @@ using System.Threading.Tasks;
 
 namespace WooCommerceTests
 {
-	[ TestFixture( "WP4_7_WC_3_6_credentials.csv" ) ]
-	[ TestFixture( "WP5_2_WC_3_6_credentials.csv" ) ]
+	[ TestFixture( "credentials_VM_sandbox.csv" ) ]
+	[ TestFixture( "credentials_cloud_sandbox.csv" ) ]
 	public class OrderTests : BaseTest
 	{
 		public OrderTests( string shopCredentialsFileName ) : base( shopCredentialsFileName ) { }

--- a/src/WooCommerceTests/ProductTests.cs
+++ b/src/WooCommerceTests/ProductTests.cs
@@ -11,8 +11,8 @@ using WooCommerceNET;
 
 namespace WooCommerceTests
 {
-	[ TestFixture( "WP5_2_WC_3_6_credentials.csv" ) ]
-	[ TestFixture( "WP4_7_WC_3_6_credentials.csv" ) ]
+	[ TestFixture( "credentials_cloud_sandbox.csv" ) ]
+	[ TestFixture( "credentials_VM_sandbox.csv" ) ]
 	public class ProductTests : BaseTest
 	{
 		private const string testSku = "testsku";

--- a/src/WooCommerceTests/SystemStatusServiceTests.cs
+++ b/src/WooCommerceTests/SystemStatusServiceTests.cs
@@ -2,8 +2,8 @@
 
 namespace WooCommerceTests
 {
-	[ TestFixture( "WP4_7_WC_3_6_credentials.csv" ) ]
-	[ TestFixture( "WP5_2_WC_3_6_credentials.csv" ) ]
+	[ TestFixture( "credentials_VM_sandbox.csv" ) ]
+	[ TestFixture( "credentials_cloud_sandbox.csv" ) ]
 	public class SystemStatusServiceTests : BaseTest
 	{
 		public SystemStatusServiceTests( string shopCredentialsFileName ) : base( shopCredentialsFileName ) { }

--- a/src/WooCommerceTests/VariationTests.cs
+++ b/src/WooCommerceTests/VariationTests.cs
@@ -10,8 +10,8 @@ using WooCommerceNET;
 
 namespace WooCommerceTests
 {
-	[ TestFixture( "WP5_2_WC_3_6_credentials.csv" ) ]
-	[ TestFixture( "WP4_7_WC_3_6_credentials.csv" ) ]
+	[ TestFixture( "credentials_cloud_sandbox.csv" ) ]
+	[ TestFixture( "credentials_VM_sandbox.csv" ) ]
 	public class VariationTests : BaseTest
 	{
 		private ApiV3WCObject _apiV3WcObject;

--- a/src/WooCommerceTests/WooCommerceTests.csproj
+++ b/src/WooCommerceTests/WooCommerceTests.csproj
@@ -65,8 +65,8 @@
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="WooCommerce.NET, Version=1.1.0.4, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\WooCommerceNET.SV.1.1.0.4\lib\net461\WooCommerce.NET.dll</HintPath>
+    <Reference Include="WooCommerce.NET, Version=1.1.5.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\WooCommerceNET.SV.1.1.5\lib\net461\WooCommerce.NET.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/WooCommerceTests/packages.config
+++ b/src/WooCommerceTests/packages.config
@@ -6,5 +6,5 @@
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
   <package id="NUnit" version="3.12.0" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
-  <package id="WooCommerceNET.SV" version="1.1.0.4" targetFramework="net461" />
+  <package id="WooCommerceNET.SV" version="1.1.5" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
…_status > theme > override, since it causes issues for a Woo 4.1.1 client; renamed test credentials files to not have the Woo version in the name