### PR TITLE
2020-06-30 GUARD-656 Orders-Sync-Error & GUARD-667 Inv Sync Error

### DIFF
--- a/src/WooCommerceAccess/Models/Product.cs
+++ b/src/WooCommerceAccess/Models/Product.cs
@@ -92,8 +92,8 @@ namespace WooCommerceAccess.Models
 
 		public static Dictionary< string, string > ToAttributeDictionary( this List< ProductAttributeLine > attributeLines )
 		{
-			return attributeLines.Where( a => a.options != null && a.options.Count == 1 ).
-				ToDictionary( a => a.name, a => a.options.First() );
+			return attributeLines.Where( a => !string.IsNullOrWhiteSpace( a.name ) && a.options != null && a.options.Count == 1)
+				.ToDictionary( a => a.name, a => a.options.First() );
 		}
 
 		public static decimal ToDecimal( this string str )

--- a/src/WooCommerceAccess/Models/Variation.cs
+++ b/src/WooCommerceAccess/Models/Variation.cs
@@ -62,7 +62,8 @@ namespace WooCommerceAccess.Models
 				Weight = variationV3.weight,
 				SalePrice = variationV3.sale_price,
 				RegularPrice = variationV3.regular_price,
-				Attributes = variationV3.attributes?.ToDictionary( a => a.name, a => a.option ),
+				Attributes = variationV3.attributes?.Where( a => !string.IsNullOrWhiteSpace( a.name ) )
+					.ToDictionary( a => a.name, a => a.option ),
 				UpdatedDateUtc = variationV3.date_modified_gmt,
 				CreatedDateUtc = variationV3.date_created_gmt,
 				ManagingStock = (bool?) variationV3.manage_stock

--- a/src/WooCommerceAccess/Services/ApiV3WCObject.cs
+++ b/src/WooCommerceAccess/Services/ApiV3WCObject.cs
@@ -196,7 +196,7 @@ namespace WooCommerceAccess.Services
 							id = v.Id, sku = v.Sku, stock_quantity = v.Quantity
 						} ).ToList();
 					var batchResult = await this._wcObjectApiV3.Product.Variations.UpdateRange( variationsUpdateRequest.Key.Id, wooCommerceVariationBatch );
-					result.AddRange( batchResult.update.Select( prV3 => prV3.ToSvVariation() ) );
+					result.AddRange( batchResult.update.Where( x => !string.IsNullOrWhiteSpace( x.sku ) ).Select( prV3 => prV3.ToSvVariation() ) );
 				}
 			}
 

--- a/src/WooCommerceAccess/WooCommerceAccess.csproj
+++ b/src/WooCommerceAccess/WooCommerceAccess.csproj
@@ -9,10 +9,10 @@
     <PackageLicenseUrl>https://github.com/skuvault/wooCommerceAccess/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/wooCommerceAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault/wooCommerceAccess</RepositoryUrl>
-    <Version>1.3.1.0</Version>
+    <Version>1.3.2.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.3.1.0</AssemblyVersion>
-    <FileVersion>1.3.1.0</FileVersion>
+    <AssemblyVersion>1.3.2.0</AssemblyVersion>
+    <FileVersion>1.3.2.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,7 +21,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="Polly-Signed" Version="5.9.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="WooCommerceNET.SV" Version="1.1.5" />
+    <PackageReference Include="WooCommerceNET.SV" Version="1.1.6" />
   </ItemGroup>
 
 </Project>

--- a/src/WooCommerceAccess/WooCommerceAccess.csproj
+++ b/src/WooCommerceAccess/WooCommerceAccess.csproj
@@ -9,10 +9,10 @@
     <PackageLicenseUrl>https://github.com/skuvault/wooCommerceAccess/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/wooCommerceAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault/wooCommerceAccess</RepositoryUrl>
-    <Version>1.2.3.0</Version>
+    <Version>1.3.0.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.2.3.0</AssemblyVersion>
-    <FileVersion>1.2.3.0</FileVersion>
+    <AssemblyVersion>1.3.0.0</AssemblyVersion>
+    <FileVersion>1.3.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/WooCommerceAccess/WooCommerceAccess.csproj
+++ b/src/WooCommerceAccess/WooCommerceAccess.csproj
@@ -9,10 +9,10 @@
     <PackageLicenseUrl>https://github.com/skuvault/wooCommerceAccess/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/wooCommerceAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault/wooCommerceAccess</RepositoryUrl>
-    <Version>1.3.0.0</Version>
+    <Version>1.3.1.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.3.0.0</AssemblyVersion>
-    <FileVersion>1.3.0.0</FileVersion>
+    <AssemblyVersion>1.3.1.0</AssemblyVersion>
+    <FileVersion>1.3.1.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/WooCommerceTests/WooCommerceTests.csproj
+++ b/src/WooCommerceTests/WooCommerceTests.csproj
@@ -65,8 +65,8 @@
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="WooCommerce.NET, Version=1.1.5.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\WooCommerceNET.SV.1.1.5\lib\net461\WooCommerce.NET.dll</HintPath>
+    <Reference Include="WooCommerce.NET, Version=1.1.6.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\WooCommerceNET.SV.1.1.6\lib\net461\WooCommerce.NET.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/WooCommerceTests/packages.config
+++ b/src/WooCommerceTests/packages.config
@@ -6,5 +6,5 @@
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
   <package id="NUnit" version="3.12.0" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
-  <package id="WooCommerceNET.SV" version="1.1.5" targetFramework="net461" />
+  <package id="WooCommerceNET.SV" version="1.1.6" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
Summary
Fixed issue with customer object deserialization (it's part of pull orders response), created_at field can contain incorrect date and time value.